### PR TITLE
[ED-18686] Tweak: Add Site Planner to Elementor Home screen

### DIFF
--- a/assets/images/app/ai/ai-site-creator-homepage-bg.svg
+++ b/assets/images/app/ai/ai-site-creator-homepage-bg.svg
@@ -1,0 +1,72 @@
+<svg width="983" height="655" viewBox="0 0 983 655" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="mask0_14305_49091" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="47" y="239" width="888" height="177">
+<rect x="47.541" y="239" width="887" height="177" rx="8" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_14305_49091)">
+<g style="mix-blend-mode:multiply" opacity="0.16" clip-path="url(#clip0_14305_49091)">
+<rect width="554.066" height="529.346" transform="translate(763.254 -30.2627) rotate(41.4963)" fill="white"/>
+<g filter="url(#filter0_f_14305_49091)">
+<circle cx="861.591" cy="296.75" r="120.921" transform="rotate(41.4963 861.591 296.75)" fill="black"/>
+<circle cx="862.468" cy="411.107" r="142.84" transform="rotate(-123.504 862.468 411.107)" fill="black"/>
+<circle cx="157.343" cy="157.343" r="157.343" transform="matrix(0.70696 0.707254 0.707254 -0.70696 490.23 350.083)" fill="black"/>
+<circle cx="111.789" cy="111.789" r="111.789" transform="matrix(0.587351 0.809332 0.809332 -0.587351 669.936 432.411)" fill="black"/>
+<circle cx="841.699" cy="403.959" r="131.612" transform="rotate(41.4963 841.699 403.959)" fill="black"/>
+</g>
+<g style="mix-blend-mode:color-dodge">
+<rect x="762.863" y="-29.8213" width="582.461" height="547.055" transform="rotate(41.4963 762.863 -29.8213)" fill="#878787"/>
+</g>
+<g style="mix-blend-mode:color-burn">
+<rect x="762.863" y="-29.8213" width="582.461" height="547.055" transform="rotate(41.4963 762.863 -29.8213)" fill="white"/>
+</g>
+<g style="mix-blend-mode:screen">
+<rect width="771.761" height="724.848" transform="translate(750.873 -159.117) rotate(41.4963)" fill="url(#paint0_linear_14305_49091)"/>
+</g>
+</g>
+<g style="mix-blend-mode:multiply" opacity="0.16" clip-path="url(#clip1_14305_49091)">
+<rect width="603.804" height="576.865" transform="translate(1332.68 161.813) rotate(133.515)" fill="white"/>
+<g filter="url(#filter1_f_14305_49091)">
+<circle cx="972.754" cy="256.359" r="131.776" transform="rotate(133.515 972.754 256.359)" fill="black"/>
+<circle cx="848.18" cy="252.928" r="155.662" transform="rotate(-31.4855 848.18 252.928)" fill="black"/>
+<circle cx="171.467" cy="171.467" r="171.467" transform="matrix(-0.731713 0.681613 0.681613 0.731713 928.928 -150.132)" fill="black"/>
+<circle cx="121.824" cy="121.824" r="121.824" transform="matrix(-0.829515 0.558484 0.558484 0.829515 832.369 42.4248)" fill="black"/>
+<circle cx="856.762" cy="230.581" r="143.427" transform="rotate(133.515 856.762 230.581)" fill="black"/>
+</g>
+<g style="mix-blend-mode:color-dodge">
+<rect x="1332.22" y="161.371" width="634.747" height="596.163" transform="rotate(133.515 1332.22 161.371)" fill="#878787"/>
+</g>
+<g style="mix-blend-mode:color-burn">
+<rect x="1332.22" y="161.371" width="634.747" height="596.163" transform="rotate(133.515 1332.22 161.371)" fill="white"/>
+</g>
+<g style="mix-blend-mode:screen">
+<rect width="841.04" height="789.916" transform="translate(1374.65 104.004) rotate(133.515)" fill="url(#paint1_linear_14305_49091)"/>
+</g>
+</g>
+</g>
+<defs>
+<filter id="filter0_f_14305_49091" x="294.633" y="-151.884" width="1026.92" height="1030" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="76.4229" result="effect1_foregroundBlur_14305_49091"/>
+</filter>
+<filter id="filter1_f_14305_49091" x="341.174" y="-365.09" width="1122.71" height="1121.28" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="83.2832" result="effect1_foregroundBlur_14305_49091"/>
+</filter>
+<linearGradient id="paint0_linear_14305_49091" x1="290.8" y1="199.757" x2="387.404" y2="454.729" gradientUnits="userSpaceOnUse">
+<stop stop-color="#F0FDFA"/>
+<stop offset="1" stop-color="#87FEE3"/>
+</linearGradient>
+<linearGradient id="paint1_linear_14305_49091" x1="316.905" y1="217.689" x2="456.784" y2="638.657" gradientUnits="userSpaceOnUse">
+<stop stop-color="#EA58F8"/>
+<stop offset="0.35" stop-color="#B28DF2"/>
+<stop offset="1" stop-color="#A0F7FC"/>
+</linearGradient>
+<clipPath id="clip0_14305_49091">
+<rect width="554.066" height="529.346" fill="white" transform="translate(763.254 -30.2627) rotate(41.4963)"/>
+</clipPath>
+<clipPath id="clip1_14305_49091">
+<rect width="603.804" height="576.865" fill="white" transform="translate(1332.68 161.813) rotate(133.515)"/>
+</clipPath>
+</defs>
+</svg>

--- a/modules/home/assets/js/components/ai-site-creator.js
+++ b/modules/home/assets/js/components/ai-site-creator.js
@@ -1,11 +1,9 @@
 import { Box, Paper, Stack, TextField } from '@elementor/ui';
 import Typography from '@elementor/ui/Typography';
 import Button from '@elementor/ui/Button';
-import PropTypes from 'prop-types';
 import { useState } from 'react';
 
-const AiSiteCreator = ( { ...props } ) => {
-	const { aiCreatorData } = props;
+const AiSiteCreator = ( { aiCreatorData } ) => {
 	const [ inputValue, setInputValue ] = useState( '' );
 
 	if ( ! aiCreatorData ) {
@@ -19,6 +17,9 @@ const AiSiteCreator = ( { ...props } ) => {
 		button_title: buttonTitle,
 		button_cta_url: buttonCtaUrl,
 		background_image: backgroundImage,
+		utm_source: utmSource,
+		utm_medium: utmMedium,
+		utm_campaign: utmCampaign,
 	} = aiCreatorData;
 
 	const handleInputChange = ( event ) => {
@@ -31,6 +32,9 @@ const AiSiteCreator = ( { ...props } ) => {
 		}
 		const url = new URL( buttonCtaUrl );
 		url.searchParams.append( 'prompt', inputValue );
+		url.searchParams.append( 'utm_source', utmSource );
+		url.searchParams.append( 'utm_medium', utmMedium );
+		url.searchParams.append( 'utm_campaign', utmCampaign );
 		return url.toString();
 	};
 
@@ -60,7 +64,8 @@ const AiSiteCreator = ( { ...props } ) => {
 					fullWidth
 					placeholder={ inputPlaceholder }
 					variant="outlined"
-					size="medium"
+					color="secondary"
+					size="small"
 					sx={ { flex: 1 } }
 					value={ inputValue }
 					onChange={ handleInputChange }
@@ -81,7 +86,7 @@ const AiSiteCreator = ( { ...props } ) => {
 };
 
 AiSiteCreator.propTypes = {
-	aiCreatorData: PropTypes.object.isRequired,
+	aiCreatorData: PropTypes.object,
 };
 
 export default AiSiteCreator;

--- a/modules/home/assets/js/components/ai-site-creator.js
+++ b/modules/home/assets/js/components/ai-site-creator.js
@@ -1,0 +1,83 @@
+import { Box, Paper, Stack, TextField } from '@elementor/ui';
+import Typography from '@elementor/ui/Typography';
+import Button from '@elementor/ui/Button';
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+
+const AiSiteCreator = ( { ...props } ) => {
+	const { aiCreatorData } = props;
+	const [ inputValue, setInputValue ] = useState( '' );
+
+	if ( ! aiCreatorData ) {
+		return null;
+	}
+
+	const {
+		title,
+		description,
+		input_placeholder: inputPlaceholder,
+		button_title: buttonTitle,
+		button_cta_url: buttonCtaUrl,
+	} = aiCreatorData;
+
+	const handleInputChange = ( event ) => {
+		setInputValue( event.target.value );
+	};
+
+	const getButtonHref = () => {
+		if ( ! inputValue ) {
+			return buttonCtaUrl;
+		}
+		const url = new URL( buttonCtaUrl );
+		url.searchParams.append( 'prompt', inputValue );
+		return url.toString();
+	};
+
+	return (
+		<Paper
+			elevation={ 0 }
+			sx={ {
+				display: 'flex',
+				flexDirection: 'column',
+				py: 3,
+				px: 4,
+				gap: 2,
+				border: '1px solid #E5E5E5',
+				borderRadius: 1,
+				borderColor: 'rgba(0, 0, 0, 0.12)',
+			} }
+		>
+			<Stack gap={ 1 } justifyContent="center">
+				<Typography variant="h6">{ title }</Typography>
+				<Typography variant="body2" color="secondary">{ description }</Typography>
+			</Stack>
+			<Box sx={ { display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: 2, mt: 1 } }>
+				<TextField
+					fullWidth
+					placeholder={ inputPlaceholder }
+					variant="outlined"
+					size="medium"
+					sx={ { flex: 1 } }
+					value={ inputValue }
+					onChange={ handleInputChange }
+				/>
+				<Button
+					variant="outlined"
+					size="small"
+					color="secondary"
+					startIcon={ <span className="eicon-ai"></span> }
+					href={ getButtonHref() }
+					target="_blank"
+				>
+					{ buttonTitle }
+				</Button>
+			</Box>
+		</Paper>
+	);
+};
+
+AiSiteCreator.propTypes = {
+	aiCreatorData: PropTypes.object.isRequired,
+};
+
+export default AiSiteCreator;

--- a/modules/home/assets/js/components/ai-site-creator.js
+++ b/modules/home/assets/js/components/ai-site-creator.js
@@ -18,6 +18,7 @@ const AiSiteCreator = ( { ...props } ) => {
 		input_placeholder: inputPlaceholder,
 		button_title: buttonTitle,
 		button_cta_url: buttonCtaUrl,
+		background_image: backgroundImage,
 	} = aiCreatorData;
 
 	const handleInputChange = ( event ) => {
@@ -44,7 +45,10 @@ const AiSiteCreator = ( { ...props } ) => {
 				gap: 2,
 				border: '1px solid #E5E5E5',
 				borderRadius: 1,
-				borderColor: 'rgba(0, 0, 0, 0.12)',
+				boxShadow: 'none',
+				backgroundImage: `url(${ backgroundImage })`,
+				backgroundSize: 'auto',
+				backgroundPosition: 'center',
 			} }
 		>
 			<Stack gap={ 1 } justifyContent="center">

--- a/modules/home/assets/js/components/home-screen.js
+++ b/modules/home/assets/js/components/home-screen.js
@@ -5,6 +5,7 @@ import SideBarPromotion from './sidebar-promotion';
 import Addons from './addons-section';
 import ExternalLinksSection from './external-links-section';
 import GetStarted from './get-started-section';
+import AiSiteCreator from './ai-site-creator';
 
 const HomeScreen = ( props ) => {
 	const hasSidebarPromotion = props.homeScreenData.hasOwnProperty( 'sidebar_promotion_variants' );
@@ -16,6 +17,7 @@ const HomeScreen = ( props ) => {
 				{ props.homeScreenData.top_with_licences && <TopSection topData={ props.homeScreenData.top_with_licences } buttonCtaUrl={ props.homeScreenData.button_cta_url } /> }
 				<Box sx={ { display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, justifyContent: 'space-between', gap: 3 } }>
 					<Stack sx={ { flex: 1, gap: 3 } }>
+						{ props.homeScreenData.ai_creator && <AiSiteCreator aiCreatorData={ props.homeScreenData.ai_creator } /> }
 						<GetStarted
 							getStartedData={ props.homeScreenData.get_started }
 							adminUrl={ props.adminUrl }

--- a/tests/phpunit/elementor/modules/home/Test_Filter_Hosting.php
+++ b/tests/phpunit/elementor/modules/home/Test_Filter_Hosting.php
@@ -55,6 +55,14 @@ class Test_Filter_Hosting extends PHPUnit_TestCase {
 					"youtube_embed_id" => "QdkDGrS8ZZs?si=s_VjZCQR6Fh1jgB5",
 				],
 			],
+			"ai_creator" => [
+				"title" => "Create and launch your site faster with AI",
+				"description" => "Share your vision with our AI Chat and watch as it becomes a brief, sitemap, and wireframes in minutes:",
+				"input_placeholder" => "Start describing the site you want to create...",
+				"button_title" => "Create with AI",
+				"button_cta_url" => "http://planner.elementor.com/chat.html",
+				"background_image" => ELEMENTOR_ASSETS_URL . 'images/app/ai/ai-site-creator-homepage-bg.svg',
+			],
 			"get_started" => [
 				[
 					"license" => [ "free" ],


### PR DESCRIPTION
## PR Type
- [x] Feature

## Summary
This PR adds an AI Site Planner promotion box to the Elementor homepage for new admin users with fewer than 10 Elementor pages and no custom kit applied, unless they are opted out from Elementor AI.

## Description
- Added a new promotional section for the AI Site Planner on the Elementor admin homepage
- Added logic to only display the promotion for sites with fewer than 10 Elementor pages
- Added conditions to hide the promotion if a custom kit is applied
- Added UTM parameters to track conversions from the homepage promotion
- Implemented proper background styling for the promotional box

## Test instructions
1. Install Elementor on a fresh site
2. Navigate to the Elementor homepage
3. Verify the AI Site Planner promotion is displayed
4. Create more than 10 pages with Elementor and verify the promotion disappears
5. Apply a custom kit and verify the promotion disappears

## Quality assurance
- [x] I have tested this code to the best of my abilities